### PR TITLE
defining artifactLifeCycle datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+lib

--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -12,4 +12,8 @@
             <inline-other index-prefix="alc-" cluster-name="default"/>
         </datasource>
     </entity-facade>
+
+    <database-list>
+        <dictionary-type type="object" java-type="java.lang.Object" default-sql-type="STRUCT"/>
+    </database-list>
 </moqui-conf>

--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -6,4 +6,10 @@
     <default-property name="elasticsearch_user" value=""/>
     <default-property name="elasticsearch_password" value="" is-secret="true"/>
 
+    <entity-facade database-locale="${default_locale}" database-time-zone="${database_time_zone ?: default_time_zone}">
+        <datasource group-name="artifactLifeCycle" runtime-add-missing="true" startup-add-missing="false"
+                    object-factory="org.moqui.impl.entity.elastic.ElasticDatasourceFactory">
+            <inline-other index-prefix="alc-" cluster-name="default"/>
+        </datasource>
+    </entity-facade>
 </moqui-conf>

--- a/patches/ElasticDatasourceFactory.patch
+++ b/patches/ElasticDatasourceFactory.patch
@@ -1,0 +1,13 @@
+diff --git a/framework/src/main/groovy/org/moqui/impl/entity/elastic/ElasticDatasourceFactory.groovy b/framework/src/main/groovy/org/moqui/impl/entity/elastic/ElasticDatasourceFactory.groovy
+index a532332c..dd79c638 100644
+--- a/framework/src/main/groovy/org/moqui/impl/entity/elastic/ElasticDatasourceFactory.groovy
++++ b/framework/src/main/groovy/org/moqui/impl/entity/elastic/ElasticDatasourceFactory.groovy
+@@ -209,7 +209,7 @@ class ElasticDatasourceFactory implements EntityDatasourceFactory {
+     static final Map<String, String> esEntityTypeMap = [id:'keyword', 'id-long':'keyword', date:'date', time:'keyword',
+             'date-time':'date', 'number-integer':'long', 'number-decimal':'double', 'number-float':'double',
+             'currency-amount':'double', 'currency-precise':'double', 'text-indicator':'keyword', 'text-short':'text',
+-            'text-medium':'text', 'text-intermediate':'text', 'text-long':'text', 'text-very-long':'text', 'binary-very-long':'binary']
++            'text-medium':'text', 'text-intermediate':'text', 'text-long':'text', 'text-very-long':'text', 'binary-very-long':'binary', object:'object']
+     static final Set<String> esEntityIsKeywordSet = esEntityTypeMap.findAll({"keyword".equals(it.value)}).keySet()
+     static final Set<String> esEntityAddKeywordSet = new HashSet<>(['text-short', 'text-medium', 'text-intermediate'])
+ 


### PR DESCRIPTION
Defining an OpenSearch Datasource and named it `artifactLifeCycle` and assigning it a prefix `alc-`

The prefix `alc-` is applicable to the names of indexes that are defined with `artifactLifeCycle` datasource group
**Ex:** `entity-name="TestEntity"` is reflecting as `alc-test_entity` (index name)

**Note**: Moqui already has a datasource named `logging` (based on OpenSearch), but IMO having a separate datasource is good to differentiate it from application logs that are going to index on OpenSearch.