### PR TITLE
Implement Service to Create Opensearch Indexes of Artifacts 

### DIFF
--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -5,7 +5,6 @@
     <default-property name="elasticsearch_url" value=""/>
     <default-property name="elasticsearch_user" value=""/>
     <default-property name="elasticsearch_password" value="" is-secret="true"/>
-    <default-property name="alc_sftp_mount_point" value="ArtifactLog"/>
 
     <entity-facade database-locale="${default_locale}" database-time-zone="${database_time_zone ?: default_time_zone}">
         <datasource group-name="artifactLifeCycle" runtime-add-missing="true" startup-add-missing="false"

--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -5,6 +5,7 @@
     <default-property name="elasticsearch_url" value=""/>
     <default-property name="elasticsearch_user" value=""/>
     <default-property name="elasticsearch_password" value="" is-secret="true"/>
+    <default-property name="alc_sftp_mount_point" value="datamanager"/>
 
     <entity-facade database-locale="${default_locale}" database-time-zone="${database_time_zone ?: default_time_zone}">
         <datasource group-name="artifactLifeCycle" runtime-add-missing="true" startup-add-missing="false"

--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -5,7 +5,7 @@
     <default-property name="elasticsearch_url" value=""/>
     <default-property name="elasticsearch_user" value=""/>
     <default-property name="elasticsearch_password" value="" is-secret="true"/>
-    <default-property name="alc_sftp_mount_point" value="datamanager"/>
+    <default-property name="alc_sftp_mount_point" value="ArtifactLog"/>
 
     <entity-facade database-locale="${default_locale}" database-time-zone="${database_time_zone ?: default_time_zone}">
         <datasource group-name="artifactLifeCycle" runtime-add-missing="true" startup-add-missing="false"

--- a/data/ArtifactLogServiceJobData.xml
+++ b/data/ArtifactLogServiceJobData.xml
@@ -2,13 +2,13 @@
 
 <entity-facade-xml type="ext">
     <moqui.service.job.ServiceJob
-            jobName="consume_AllArtifactLogs"
+            jobName="create_ArtifactLogIndexes"
             description="consume all of the newly created Artifact Logs"
-            serviceName="co.hotwax.alc.ArtifactLifeCycleServices.consume#AllArtifactLogs"
+            serviceName="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndexes"
             cronExpression="0 0/15 * * * ?"
             paused="Y"
     >
         <parameters parameterName="lastRunTime" parameterValue=""/>
-        <parameters parameterName="jobName" parameterValue="consume_AllArtifactLogs"/>
+        <parameters parameterName="jobName" parameterValue="create_ArtifactLogIndexes"/>
     </moqui.service.job.ServiceJob>
 </entity-facade-xml>

--- a/data/ArtifactLogServiceJobData.xml
+++ b/data/ArtifactLogServiceJobData.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<entity-facade-xml type="ext">
+    <moqui.service.job.ServiceJob
+            jobName="consume_AllArtifactLogs"
+            description="consume all of the newly created Artifact Logs"
+            serviceName="co.hotwax.alc.ArtifactLifeCycleServices.consume#AllArtifactLogs"
+            cronExpression="0 0/15 * * * ?"
+            paused="Y"
+    >
+        <parameters parameterName="lastRunTime" parameterValue=""/>
+        <parameters parameterName="jobName" parameterValue="consume_AllArtifactLogs"/>
+    </moqui.service.job.ServiceJob>
+</entity-facade-xml>

--- a/data/ArtifactLogServiceJobData.xml
+++ b/data/ArtifactLogServiceJobData.xml
@@ -3,7 +3,7 @@
 <entity-facade-xml type="ext">
     <moqui.service.job.ServiceJob
             jobName="create_ArtifactLogIndexes"
-            description="consume all of the newly created Artifact Logs"
+            description="Index recently updated Artifact Logs"
             serviceName="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndexes"
             cronExpression="0 0/15 * * * ?"
             paused="Y"

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -1,50 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
-    <service verb="consume" noun="AllArtifactLogs">
+    <service verb="create" noun="ArtifactLogIndexes">
+        <description>This service indexes each artifact log by calling the core service. It only process logs after the 'sinceDate', If not specified, it defaults to the last run time of the job.</description>
         <in-parameters>
-            <parameter name="sinceDate" type="Timestamp"/>
-            <parameter name="jobName"/>
+            <parameter name="sinceDate" type="Timestamp">
+                <description>The timestamp to filter artifact logs updated after this date</description>
+            </parameter>
+            <parameter name="jobName">
+                <description>jobName to get the last run time. If provided, the service will update the job's last run time.</description>
+            </parameter>
         </in-parameters>
         <actions>
+            <!-- Validate if either 'jobName' or 'sinceDate' is provided -->
             <if condition="!jobName &amp;&amp; !sinceDate">
                 <return error="true" message="Either jobName or sinceDate input parameters are required"/>
             </if>
 
+            <!-- Get the last run time of the job if sinceDate is not provided -->
             <if condition="!sinceDate">
                 <entity-find-one entity-name="moqui.service.job.ServiceJobParameter" value-field="lastRunParam">
                     <field-map field-name="parameterName" value="lastRunTime"/>
                 </entity-find-one>
                 <set field="sinceDate" from="lastRunParam?.parameterValue"/>
             </if>
+            <set field="nowDate" from="ec.user.nowTimestamp"/>
 
             <entity-find entity-name="co.hotwax.alc.ArtifactLog" list="artifactLogList">
                 <econdition field-name="lastUpdatedStamp" from="sinceDate" operator="greater" ignore-if-empty="true"/>
             </entity-find>
-            <set field="nowDate" from="ec.user.nowTimestamp"/>
 
+            <!-- Iterate through the list of artifact logs and process each one -->
             <iterate list="artifactLogList" entry="artifactLogValue">
-                <log message="================= ${artifactLogValue}"/>
                 <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactLogValue:artifactLogValue]"/>
             </iterate>
 
-            <if condition="jobName != null &amp;&amp; !jobName.isEmpty()">
+            <!-- Update the last run time of the job -->
+            <if condition="!jobName">
                 <entity-make-value entity-name="moqui.service.job.ServiceJobParameter" value-field="updateLastRunParam" map="lastRunParam"/>
                 <set field="updateLastRunParam.parameterValue" from="nowDate"/>
                 <entity-update value-field="updateLastRunParam"/>
             </if>
 
             <return message="All Artifact Logs are indexed that are updated after Datetime: ${sinceDate}"/>
-            <!--            <log message="sinceDate:${sinceDate}\njobName:${jobName}\n\nlist:${artifactLogList}"/>-->
         </actions>
     </service>
-
     <service verb="create" noun="ArtifactLogIndex">
+        <description>This service processes the provided artifact log and creates an index on opensearch.</description>
         <in-parameters>
             <parameter name="artifactEventId"/>
             <parameter name="artifactLogValue" type="Map"/>
         </in-parameters>
         <actions>
-            <if condition="artifactEventId != null &amp;&amp; !artifactEventId.isEmpty()">
+            <!-- If artifactEventId is provided, find the corresponding artifact log value -->
+            <if condition="artifactEventId">
                 <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLogValue"/>
             </if>
 
@@ -54,6 +62,7 @@
             <set field="contentType" from="ec.resource.getContentType(artifactLogValue.logFilePath)"/>
             <set field="contentStream" from="ec.resource.getLocationReference(mountPoint+artifactLogValue.logFilePath).openStream()"/>
 
+            <!-- Process the content based on its content type (JSON or CSV) -->
             <script><![CDATA[
                 import org.moqui.impl.context.ContextJavaUtil
                 import com.fasterxml.jackson.databind.JsonNode
@@ -89,10 +98,11 @@
                         contentObject.add(valueMap)
                     }
                 } else {
-                    ec.message.addError("FileType is not Supported")
+                    ec.message.addError("File Format ${contentType} is not Supported")
                     return
                 }
 
+                // Prepare the index map for creating an ArtifactLogIndex record
                 indexMap = [
                     artifactEventId: artifactLogValue.artifactEventId,
                     artifactLogId: artifactLogValue.artifactLogId,
@@ -108,6 +118,7 @@
                 ]]>
             </script>
 
+            <!-- Create a new ArtifactLogIndex Record -->
             <entity-make-value entity-name="co.hotwax.alc.ArtifactLogIndex" value-field="artifactLogIndex" map="indexMap"/>
             <entity-create value-field="artifactLogIndex"/>
         </actions>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -1,3 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
+    <service verb="create" noun="ArtifactLogIndex">
+        <in-parameters>
+            <parameter name="artifactEventId" required="true"/>
+        </in-parameters>
+        <actions>
+            <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLog"/>
+            <if condition="artifactLog == null"><return error="true" message="Artifact log with artifactEventId: ${artifactEventId} is not found"/></if>
+
+            <set field="mountPoint" value="runtime://${System.getProperty('alc_sftp_mount_point')}"/>
+            <set field="contentType" from="ec.resource.getContentType(artifactLog.logFilePath)"/>
+            <set field="contentStream" from="ec.resource.getLocationReference(mountPoint+artifactLog.logFilePath).openStream()"/>
+
+            <script><![CDATA[
+                import org.moqui.impl.context.ContextJavaUtil
+                import com.fasterxml.jackson.databind.JsonNode
+                import org.apache.commons.csv.*
+                contentObject = null
+
+                if (contentType == "application/json") {
+                    JsonNode contentRootNode = ContextJavaUtil.jacksonMapper.readTree(contentStream)
+                    if (contentRootNode.isArray()) {
+                        contentObject = contentRootNode.asList()
+                    }
+                    if (contentRootNode.isObject()) {
+                        contentObject = contentRootNode.asType(Object.class)
+                    }
+                } else if (contentType == "text/csv") {
+                    CSVParser csvParser = CSVFormat.DEFAULT.builder().setEscape((char)'\\').build().parse(new InputStreamReader(contentStream))
+                    Map<String, Integer> headerMap = [:]
+                    contentObject = []
+
+                    Iterator<CSVRecord> iterator = csvParser.iterator()
+                    CSVRecord headerRecord = iterator.next()
+                    for (int i = 0; i < headerRecord.size(); i++) headerMap.put(headerRecord.get(i), i)
+
+                    while (iterator.hasNext()) {
+                        CSVRecord record = iterator.next()
+                        valueMap = [:]
+
+                        for (Map.Entry<String, Integer> field in headerMap) {
+                            fieldValue = record.get(field.value)
+                            if (fieldValue == null) continue
+                            valueMap.put(field.key, fieldValue.isEmpty() ? null : fieldValue)
+                        }
+                        contentObject.add(valueMap)
+                    }
+                } else {
+                    ec.message.addError("FileType is not Supported")
+                    return
+                }
+
+                indexMap = [
+                    artifactEventId: artifactLog.artifactEventId,
+                    artifactLogId: artifactLog.artifactLogId,
+                    artifactLogTypeId: artifactLog.artifactLogTypeId,
+                    artifactLogIdTypeId: artifactLog.artifactLogIdTypeId,
+                    artifactLogIdSystem: artifactLog.artifactLogIdSystem,
+                    fromSystem: artifactLog.fromSystem,
+                    toSystem: artifactLog.toSystem,
+                    logOriginPath: artifactLog.logOriginPath,
+                    logFilePath: artifactLog.logFilePath,
+                    content: contentObject
+                ]
+                ]]>
+            </script>
+
+            <entity-make-value entity-name="co.hotwax.alc.ArtifactLogIndex" value-field="artifactLogIndex" map="indexMap"/>
+            <entity-create value-field="artifactLogIndex"/>
+        </actions>
+    </service>
 </services>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -19,6 +19,7 @@
             <!-- Get the last run time of the job if sinceDate is not provided -->
             <if condition="!sinceDate">
                 <entity-find-one entity-name="moqui.service.job.ServiceJobParameter" value-field="lastRunParam">
+                    <field-map field-name="jobName"/>
                     <field-map field-name="parameterName" value="lastRunTime"/>
                 </entity-find-one>
                 <set field="sinceDate" from="lastRunParam?.parameterValue"/>
@@ -30,18 +31,21 @@
             </entity-find>
 
             <!-- Iterate through the list of artifact logs and process each one -->
+            <set field="createIndexCount" value="0" type="Integer"/>
             <iterate list="artifactLogList" entry="artifactLogValue">
                 <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactLogValue:artifactLogValue]"/>
+                <set field="createIndexCount" from="createIndexCount + 1"/>
             </iterate>
 
             <!-- Update the last run time of the job -->
-            <if condition="!jobName">
-                <entity-make-value entity-name="moqui.service.job.ServiceJobParameter" value-field="updateLastRunParam" map="lastRunParam"/>
-                <set field="updateLastRunParam.parameterValue" from="nowDate"/>
-                <entity-update value-field="updateLastRunParam"/>
+            <if condition="jobName">
+                <service-call
+                    name="update#moqui.service.job.ServiceJobParameter"
+                    in-map="[jobName:jobName, parameterName:'lastRunTime', parameterValue:nowDate]"
+                />
             </if>
 
-            <return message="All Artifact Logs are indexed that are updated after Datetime: ${sinceDate}"/>
+            <return message="Total ${createIndexCount} Artifact Logs are indexed that are updated after Datetime: ${sinceDate}"/>
         </actions>
     </service>
     <service verb="create" noun="ArtifactLogIndex">

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -46,7 +46,7 @@
                 />
             </if>
 
-            <return message="Total ${createIndexCount} Artifact Logs are indexed that are updated after Datetime: ${sinceDate}"/>
+            <return message="${createIndexCount} Artifact Logs were indexed from ${sinceDate}"/>
         </actions>
     </service>
     <service verb="create" noun="ArtifactLogIndex">

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -1,5 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
+    <service verb="consume" noun="AllArtifactLogs">
+        <in-parameters>
+            <parameter name="sinceDate" type="Timestamp"/>
+            <parameter name="jobName"/>
+        </in-parameters>
+        <actions>
+            <if condition="!jobName &amp;&amp; !sinceDate">
+                <return error="true" message="Either jobName or sinceDate input parameters are required"/>
+            </if>
+
+            <if condition="!sinceDate">
+                <entity-find-one entity-name="moqui.service.job.ServiceJobParameter" value-field="lastRunParam">
+                    <field-map field-name="parameterName" value="lastRunTime"/>
+                </entity-find-one>
+                <set field="sinceDate" from="lastRunParam?.parameterValue"/>
+            </if>
+
+            <entity-find entity-name="co.hotwax.alc.ArtifactLog" list="artifactLogList">
+                <econdition field-name="lastUpdatedStamp" from="sinceDate" operator="greater" ignore-if-empty="true"/>
+            </entity-find>
+            <set field="nowDate" from="ec.user.nowTimestamp"/>
+
+            <iterate list="artifactLogList" entry="artifactLogValue">
+                <log message="================= ${artifactLogValue}"/>
+                <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactLogValue:artifactLogValue]"/>
+            </iterate>
+
+            <if condition="jobName != null &amp;&amp; !jobName.isEmpty()">
+                <entity-make-value entity-name="moqui.service.job.ServiceJobParameter" value-field="updateLastRunParam" map="lastRunParam"/>
+                <set field="updateLastRunParam.parameterValue" from="nowDate"/>
+                <entity-update value-field="updateLastRunParam"/>
+            </if>
+
+            <return message="All Artifact Logs are indexed that are updated after Datetime: ${sinceDate}"/>
+            <!--            <log message="sinceDate:${sinceDate}\njobName:${jobName}\n\nlist:${artifactLogList}"/>-->
+        </actions>
+    </service>
+
     <service verb="create" noun="ArtifactLogIndex">
         <in-parameters>
             <parameter name="artifactEventId"/>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -62,10 +62,8 @@
 
             <if condition="artifactLogValue == null"><return error="true" message="Artifact Log is not found"/></if>
 
-            <set field="mountPoint" value="runtime://${System.getProperty('alc_sftp_mount_point')}"/>
             <set field="contentType" from="ec.resource.getContentType(artifactLogValue.logFilePath)"/>
-            <set field="contentStream" from="ec.resource.getLocationReference(mountPoint+artifactLogValue.logFilePath).openStream()"/>
-
+            <set field="contentStream" from="ec.resource.getLocationReference(artifactLogValue.logFilePath).openStream()"/>
             <!-- Process the content based on its content type (JSON or CSV) -->
             <script><![CDATA[
                 import org.moqui.impl.context.ContextJavaUtil

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -33,8 +33,8 @@
 
             <!-- Iterate through the list of artifact logs and process each one -->
             <set field="createIndexCount" value="0" type="Integer"/>
-            <iterate list="artifactLogList" entry="artifactLogValue">
-                <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactEventId:artifactLogValue.artifactEventId]"/>
+            <iterate list="artifactLogList" entry="artifactEvent">
+                <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactEventId:artifactEvent.artifactEventId]"/>
                 <set field="createIndexCount" from="createIndexCount + 1"/>
             </iterate>
 
@@ -56,11 +56,11 @@
         </in-parameters>
         <actions>
             <!-- Find the corresponding artifact log value -->
-            <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLogValue"/>
-            <if condition="artifactLogValue == null"><return error="true" message="Artifact Log is not found"/></if>
+            <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLog"/>
+            <if condition="artifactLog == null"><return error="true" message="Artifact Log is not found"/></if>
 
-            <set field="contentType" from="ec.resource.getContentType(artifactLogValue.logFilePath)"/>
-            <set field="contentStream" from="ec.resource.getLocationReference(artifactLogValue.logFilePath).openStream()"/>
+            <set field="contentType" from="ec.resource.getContentType(artifactLog.logFilePath)"/>
+            <set field="contentStream" from="ec.resource.getLocationReference(artifactLog.logFilePath).openStream()"/>
 
             <!-- Process the content based on its content type (JSON or CSV) -->
             <script><![CDATA[
@@ -104,15 +104,15 @@
 
                 // Prepare the index map for creating an ArtifactLogIndex record
                 indexMap = [
-                    artifactEventId: artifactLogValue.artifactEventId,
-                    artifactLogId: artifactLogValue.artifactLogId,
-                    artifactLogTypeId: artifactLogValue.artifactLogTypeId,
-                    artifactLogIdTypeId: artifactLogValue.artifactLogIdTypeId,
-                    artifactLogIdSystem: artifactLogValue.artifactLogIdSystem,
-                    fromSystem: artifactLogValue.fromSystem,
-                    toSystem: artifactLogValue.toSystem,
-                    logOriginPath: artifactLogValue.logOriginPath,
-                    logFilePath: artifactLogValue.logFilePath,
+                    artifactEventId: artifactLog.artifactEventId,
+                    artifactLogId: artifactLog.artifactLogId,
+                    artifactLogTypeId: artifactLog.artifactLogTypeId,
+                    artifactLogIdTypeId: artifactLog.artifactLogIdTypeId,
+                    artifactLogIdSystem: artifactLog.artifactLogIdSystem,
+                    fromSystem: artifactLog.fromSystem,
+                    toSystem: artifactLog.toSystem,
+                    logOriginPath: artifactLog.logOriginPath,
+                    logFilePath: artifactLog.logFilePath,
                     content: contentObject
                 ]
                 ]]>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -2,15 +2,19 @@
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
     <service verb="create" noun="ArtifactLogIndex">
         <in-parameters>
-            <parameter name="artifactEventId" required="true"/>
+            <parameter name="artifactEventId"/>
+            <parameter name="artifactLogValue" type="Map"/>
         </in-parameters>
         <actions>
-            <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLog"/>
-            <if condition="artifactLog == null"><return error="true" message="Artifact log with artifactEventId: ${artifactEventId} is not found"/></if>
+            <if condition="artifactEventId != null &amp;&amp; !artifactEventId.isEmpty()">
+                <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLogValue"/>
+            </if>
+
+            <if condition="artifactLogValue == null"><return error="true" message="Artifact Log is not found"/></if>
 
             <set field="mountPoint" value="runtime://${System.getProperty('alc_sftp_mount_point')}"/>
-            <set field="contentType" from="ec.resource.getContentType(artifactLog.logFilePath)"/>
-            <set field="contentStream" from="ec.resource.getLocationReference(mountPoint+artifactLog.logFilePath).openStream()"/>
+            <set field="contentType" from="ec.resource.getContentType(artifactLogValue.logFilePath)"/>
+            <set field="contentStream" from="ec.resource.getLocationReference(mountPoint+artifactLogValue.logFilePath).openStream()"/>
 
             <script><![CDATA[
                 import org.moqui.impl.context.ContextJavaUtil
@@ -52,15 +56,15 @@
                 }
 
                 indexMap = [
-                    artifactEventId: artifactLog.artifactEventId,
-                    artifactLogId: artifactLog.artifactLogId,
-                    artifactLogTypeId: artifactLog.artifactLogTypeId,
-                    artifactLogIdTypeId: artifactLog.artifactLogIdTypeId,
-                    artifactLogIdSystem: artifactLog.artifactLogIdSystem,
-                    fromSystem: artifactLog.fromSystem,
-                    toSystem: artifactLog.toSystem,
-                    logOriginPath: artifactLog.logOriginPath,
-                    logFilePath: artifactLog.logFilePath,
+                    artifactEventId: artifactLogValue.artifactEventId,
+                    artifactLogId: artifactLogValue.artifactLogId,
+                    artifactLogTypeId: artifactLogValue.artifactLogTypeId,
+                    artifactLogIdTypeId: artifactLogValue.artifactLogIdTypeId,
+                    artifactLogIdSystem: artifactLogValue.artifactLogIdSystem,
+                    fromSystem: artifactLogValue.fromSystem,
+                    toSystem: artifactLogValue.toSystem,
+                    logOriginPath: artifactLogValue.logOriginPath,
+                    logFilePath: artifactLogValue.logFilePath,
                     content: contentObject
                 ]
                 ]]>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -28,12 +28,13 @@
 
             <entity-find entity-name="co.hotwax.alc.ArtifactLog" list="artifactLogList">
                 <econdition field-name="lastUpdatedStamp" from="sinceDate" operator="greater" ignore-if-empty="true"/>
+                <select-field field-name="artifactEventId"/>
             </entity-find>
 
             <!-- Iterate through the list of artifact logs and process each one -->
             <set field="createIndexCount" value="0" type="Integer"/>
             <iterate list="artifactLogList" entry="artifactLogValue">
-                <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactLogValue:artifactLogValue]"/>
+                <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.create#ArtifactLogIndex" in-map="[artifactEventId:artifactLogValue.artifactEventId]"/>
                 <set field="createIndexCount" from="createIndexCount + 1"/>
             </iterate>
 
@@ -51,19 +52,16 @@
     <service verb="create" noun="ArtifactLogIndex">
         <description>This service processes the provided Artifact Log and creates an index on OpenSearch.</description>
         <in-parameters>
-            <parameter name="artifactEventId"/>
-            <parameter name="artifactLogValue" type="Map"/>
+            <parameter name="artifactEventId" required="true"/>
         </in-parameters>
         <actions>
-            <!-- If artifactEventId is provided, find the corresponding artifact log value -->
-            <if condition="artifactEventId">
-                <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLogValue"/>
-            </if>
-
+            <!-- Find the corresponding artifact log value -->
+            <entity-find-one entity-name="co.hotwax.alc.ArtifactLog" value-field="artifactLogValue"/>
             <if condition="artifactLogValue == null"><return error="true" message="Artifact Log is not found"/></if>
 
             <set field="contentType" from="ec.resource.getContentType(artifactLogValue.logFilePath)"/>
             <set field="contentStream" from="ec.resource.getLocationReference(artifactLogValue.logFilePath).openStream()"/>
+
             <!-- Process the content based on its content type (JSON or CSV) -->
             <script><![CDATA[
                 import org.moqui.impl.context.ContextJavaUtil

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -4,7 +4,7 @@
         <description>This service indexes each artifact log by calling the core service. It only process logs after the 'sinceDate', If not specified, it defaults to the last run time of the job.</description>
         <in-parameters>
             <parameter name="sinceDate" type="Timestamp">
-                <description>The timestamp to filter artifact logs updated after this date</description>
+                <description>Filter Artifact Logs updated after this date time</description>
             </parameter>
             <parameter name="jobName">
                 <description>jobName to get the last run time. If provided, the service will update the job's last run time.</description>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -49,7 +49,7 @@
         </actions>
     </service>
     <service verb="create" noun="ArtifactLogIndex">
-        <description>This service processes the provided artifact log and creates an index on opensearch.</description>
+        <description>This service processes the provided Artifact Log and creates an index on OpenSearch.</description>
         <in-parameters>
             <parameter name="artifactEventId"/>
             <parameter name="artifactLogValue" type="Map"/>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -100,7 +100,7 @@
                         contentObject.add(valueMap)
                     }
                 } else {
-                    ec.message.addError("File Format ${contentType} is not Supported")
+                    ec.message.addError("${contentType} file format is not supported. Please upload a JSON or CSV")
                     return
                 }
 


### PR DESCRIPTION
I've Implemented the below services
### 1. `create#ArtifactLogIndexs`: (wrapper service)
This service lists all the newly updated artifact logs and calls the core service to create indexes of artifacts

### 2. `create#ArtifactLogIndex`: (core service)
Core service to create an index of a single artifact log, this service handles the content based on the content file format