### PR TITLE
Add dropdown on find page to filter by Artifact Log type

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -20,15 +20,25 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <actions>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" in-map="[queryString:queryString, pageIndex:pageIndex, pageSize:pageSize, pageNoLimit:pageNoLimit]" out-map="context"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageIndex:pageIndex, pageSize:pageSize, pageNoLimit:pageNoLimit]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>
         <form-single name="FindArtifactLogIndex" transition="." focus-field="anyField">
-            <field name="anyField"><default-field title="">
-                <text-line size="100"/></default-field></field>
+            <field name="anyField"><default-field title=""><text-line size="100"/></default-field></field>
+            <field name="artifactLogTypeId"><default-field title="Artifact Log Type">
+                <drop-down allow-empty="true">
+                    <entity-options key="${artifactLogTypeId}" text="${artifactLogTypeName}">
+                        <entity-find entity-name="co.hotwax.alc.ArtifactLogType"/>
+                    </entity-options>
+                </drop-down>
+            </default-field></field>
             <field name="submitButton"><default-field title="Search"><submit/></default-field></field>
-            <field-layout><field-row-big><field-ref name="anyField"/><field-ref name="submitButton"/></field-row-big></field-layout>
+            <field-layout><field-row-big>
+                <field-ref name="anyField"/>
+                <field-ref name="artifactLogTypeId"/>
+                <field-ref name="submitButton"/>
+            </field-row-big></field-layout>
         </form-single>
         <form-list name="ArtifactLogIndexList" list="documentList" skip-form="true" header-dialog="true" saved-finds="true"
                    show-xlsx-button="true" show-csv-button="true" show-page-size="true">

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -19,7 +19,9 @@ along with this software (see the LICENSE.md file). If not, see
         </description>
         <in-parameters>
             <parameter name="queryString" required="true"/>
-            <parameter name="additionalQueryMap" type="Map"/>
+            <parameter name="additionalQueryMap" type="Map">
+                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
+            </parameter>
             <parameter name="pageSize" type="Integer" default="20"/>
             <parameter name="pageIndex" type="Integer" default="0"/>
             <parameter name="pageNoLimit" type="Boolean" default="false"/>
@@ -64,7 +66,8 @@ along with this software (see the LICENSE.md file). If not, see
                                         query: queryString
                                     ]
                                 ]
-                            ]
+                            ],
+                            minimum_should_match: 0,
                         ]
                     ],
                     from : fromOffset,
@@ -77,7 +80,7 @@ along with this software (see the LICENSE.md file). If not, see
                 }
 
                 if (additionalQueryMap) {
-                    searchMap.query.bool.should.add(additionalQueryMap)
+                    searchMap.query.bool.put("must", additionalQueryMap.collect {key, value -> [term: [(key): value]]})
                 }
 
                 Map validateRespMap = elasticClient.validateQuery(index, searchMap.query, true)

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -30,7 +30,8 @@ along with this software (see the LICENSE.md file). If not, see
         <out-parameters>
             <parameter name="documentList" type="List"><parameter name="document" type="Map"/></parameter>
             <parameter name="documentListCount" type="Integer">
-                <description>The total count of hits, not just the limited number returned.</description></parameter>
+                <description>The total count of hits, not just the limited number returned.</description>
+            </parameter>
             <parameter name="documentListPageIndex" type="Integer"/>
             <parameter name="documentListPageSize" type="Integer"/>
             <parameter name="documentListPageMaxIndex" type="Integer"/>
@@ -67,7 +68,7 @@ along with this software (see the LICENSE.md file). If not, see
                                     ]
                                 ]
                             ],
-                            minimum_should_match: 0,
+                            minimum_should_match: 1,
                         ]
                     ],
                     from : fromOffset,
@@ -80,7 +81,8 @@ along with this software (see the LICENSE.md file). If not, see
                 }
 
                 if (additionalQueryMap) {
-                    searchMap.query.bool.put("must", additionalQueryMap.collect {key, value -> [term: [(key): value]]})
+                    List mustList = additionalQueryMap.findAll { it.value != null }.collect { key, value -> [term: [(key): value]] }
+                    if (!mustList.isEmpty()) searchMap.query.bool.put("must", mustList)
                 }
 
                 Map validateRespMap = elasticClient.validateQuery(index, searchMap.query, true)


### PR DESCRIPTION
Close: #25 

Update the SearchService to make use of the `additionalQueryMap` input parameter as the must-have values correspond to the field names available at the top level in the `ArtifactLogIndex` search index.

![image](https://github.com/user-attachments/assets/7bd82466-a6a4-4e30-aaab-b30aca6d1407)