### PR TITLE
Fix: The details page not showing the list Related Artifacts

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -28,7 +28,7 @@ along with this software (see the LICENSE.md file). If not, see
             <return message="Artifact Log ${artifactEventId} is not found"/>
         </if>
         <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
-        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="[queryString:artifactLogId, additionalQueryMap:[match:[artifactLogId:artifactLogId]], pageIndex:pageIndex, pageSize:pageSize, pageNoLimit:pageNoLimit]"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId]"/>
     </actions>
     <widgets>
         <label text="View Artifact Event Details" type="h3"/>


### PR DESCRIPTION
This bug is due to passing additionalQueryMap which is not required