### PR TITLE
Only Show Distinct Artifact Log Ids on Search Results Page

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <actions>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageIndex:pageIndex, pageSize:pageSize, pageNoLimit:pageNoLimit]" out-map="context"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#DistantArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>
@@ -40,17 +40,15 @@ along with this software (see the LICENSE.md file). If not, see
                 <field-ref name="submitButton"/>
             </field-row-big></field-layout>
         </form-single>
+        <label text="Showing only 20 records in case of no search string is given" type="strong" style="text-warning" condition="!anyField"/>
         <form-list name="ArtifactLogIndexList" list="documentList" skip-form="true" header-dialog="true" saved-finds="true"
-                   show-xlsx-button="true" show-csv-button="true" show-page-size="true">
+                   show-xlsx-button="true" show-csv-button="true" paginate="false">
             <field name="artifactEventId">
                 <header-field show-order-by="true"/>
-                <default-field><link url="viewArtifactEvent" text="${artifactEventId}" link-type="anchor"/></default-field>
-            </field>
-            <field name="artifactLogId">
-                <header-field show-order-by="true"><text-line size="20"/></header-field>
-                <default-field><display/></default-field>
+                <default-field title="Artifact Log Id"><link url="viewArtifactEvent" text="${artifactLogId}" link-type="anchor-button"/></default-field>
             </field>
 
+            <field name="statusId"><default-field><display/></default-field></field>
             <field name="artifactLogTypeId"><default-field><display/></default-field></field>
             <field name="fromSystem"><default-field><display/></default-field></field>
             <field name="toSystem"><default-field><display/></default-field></field>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <actions>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#DistantArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#RecentArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -13,15 +13,9 @@ along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
-    <service verb="search" noun="ArtifactLogIndexes">
-        <description>
-            Search for ArtifactLogIndex
-        </description>
+    <service verb="search" noun="ArtifactLogDocuments" type="interface">
+        <description>This is interface service for searching Artifact Logs</description>
         <in-parameters>
-            <parameter name="queryString" required="true"/>
-            <parameter name="additionalQueryMap" type="Map">
-                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
-            </parameter>
             <parameter name="pageSize" type="Integer" default="20"/>
             <parameter name="pageIndex" type="Integer" default="0"/>
             <parameter name="pageNoLimit" type="Boolean" default="false"/>
@@ -38,6 +32,17 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="documentListPageRangeLow" type="Integer"/>
             <parameter name="documentListPageRangeHigh" type="Integer"/>
         </out-parameters>
+    </service>
+
+    <service verb="search" noun="ArtifactLogIndexes">
+        <description>Search for ArtifactLogIndex</description>
+        <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
+        <in-parameters>
+            <parameter name="queryString" required="true"/>
+            <parameter name="additionalQueryMap" type="Map">
+                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
+            </parameter>
+        </in-parameters>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
             <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
@@ -77,7 +82,7 @@ along with this software (see the LICENSE.md file). If not, see
                 ]
 
                 if (artifactEventId) {
-                    searchMap.query.bool.must_not = [[match: [artifactEventId: artifactEventId]]]
+                    searchMap.query.bool.must_not = [[term: [artifactEventId: artifactEventId]]]
                 }
 
                 if (additionalQueryMap) {

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -121,7 +121,7 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
     
-    <service verb="search" noun="DistantArtifactLogs">
+    <service verb="search" noun="RecentArtifactLogs">
         <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
@@ -140,7 +140,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                 // In elastic/open search, the aggregations are required to be named
                 def distinctAggName = "distinct"
-                def distantAggName = "distant"
+                def recentAggName = "recent"
 
                 def searchMap = [
                     query: [ bool: [
@@ -152,9 +152,9 @@ along with this software (see the LICENSE.md file). If not, see
                             field: 'artifactLogId',
                             size: 10000
                         ],
-                        aggs: [(distantAggName): [top_hits: [
+                        aggs: [(recentAggName): [top_hits: [
                             sort: [['lastUpdatedStamp': 'desc']],
-                            size: 1 // for getting most distant artifact
+                            size: 1 // for getting only most recent artifact
                         ]]]
                     ]],
                     sort : ["_score"]
@@ -181,9 +181,9 @@ along with this software (see the LICENSE.md file). If not, see
                 documentList = []
 
                 for (Map bucket in bucketsList) {
-                    Map distantHit = (Map) bucket.(distantAggName).hits.hits[0]
-                    Map document = (Map) distantHit._source
-                    document._id = distantHit._id
+                    Map recentHit = (Map) bucket.(recentAggName).hits.hits[0]
+                    Map document = (Map) recentHit._source
+                    document._id = recentHit._id
                     documentList.add(document)
                 }
                 ]]></script>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -16,6 +16,10 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="search" noun="ArtifactLogDocuments" type="interface">
         <description>This is interface service for searching Artifact Logs</description>
         <in-parameters>
+            <parameter name="queryString" required="true"/>
+            <parameter name="additionalQueryMap" type="Map">
+                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
+            </parameter>
             <parameter name="pageSize" type="Integer" default="20"/>
             <parameter name="pageIndex" type="Integer" default="0"/>
             <parameter name="pageNoLimit" type="Boolean" default="false"/>
@@ -37,12 +41,6 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="search" noun="ArtifactLogIndexes">
         <description>Search for ArtifactLogIndex</description>
         <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
-        <in-parameters>
-            <parameter name="queryString" required="true"/>
-            <parameter name="additionalQueryMap" type="Map">
-                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
-            </parameter>
-        </in-parameters>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
             <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
@@ -120,6 +118,75 @@ along with this software (see the LICENSE.md file). If not, see
                 if (documentListPageRangeHigh > documentListCount) documentListPageRangeHigh = documentListCount
 
             ]]></script>
+        </actions>
+    </service>
+    
+    <service verb="search" noun="DistantArtifactLogs">
+        <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
+        <actions>
+            <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
+            <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
+
+            <script><![CDATA[
+                ed = ec.entity.getEntityDefinition("co.hotwax.alc.ArtifactLogIndex")
+                edf = ed.entityInfo.datasourceFactory
+                indexName = edf.getIndexName(ed)
+                def elasticClient = ec.factory.elastic.getClient(edf.clusterName)
+
+                if(elasticClient == null) {
+                    ec.logger.info("No Elastic Client found for cluster name ${edf.clusterName}, not indexing documents")
+                    return
+                }
+
+                // In elastic/open search, the aggregations are required to be named
+                def distinctAggName = "distinct"
+                def distantAggName = "distant"
+
+                def searchMap = [
+                    query: [ bool: [
+                        should:[[query_string: [query: queryString]]],
+                        minimum_should_match: 1,
+                    ]],
+                    aggs: [(distinctAggName): [
+                        terms: [
+                            field: 'artifactLogId',
+                            size: 10000
+                        ],
+                        aggs: [(distantAggName): [top_hits: [
+                            sort: [['lastUpdatedStamp': 'desc']],
+                            size: 1 // for getting most distant artifact
+                        ]]]
+                    ]],
+                    sort : ["_score"]
+                ]
+
+                if (!queryString) {
+                    searchMap.aggs.(distinctAggName).terms.put("size", 20)
+                }
+
+                if (additionalQueryMap) {
+                    List mustList = additionalQueryMap.findAll { it.value != null }.collect { key, value -> [term: [(key): value]] }
+                    if (!mustList.isEmpty()) searchMap.query.bool.put("must", mustList)
+                }
+
+                Map validateRespMap = elasticClient.validateQuery(index, searchMap.query, true)
+                if (validateRespMap != null) {
+                    ec.message.addMessage("Invalid search: ${queryString}", "danger")
+                    documentListCount = 0
+                    return
+                }
+
+                Map resultMap = elasticClient.search(indexName, searchMap)
+                List<Map> bucketsList = (List) resultMap.aggregations.(distinctAggName).buckets
+                documentList = []
+
+                for (Map bucket in bucketsList) {
+                    Map distantHit = (Map) bucket.(distantAggName).hits.hits[0]
+                    Map document = (Map) distantHit._source
+                    document._id = distantHit._id
+                    documentList.add(document)
+                }
+                ]]></script>
         </actions>
     </service>
 </services>


### PR DESCRIPTION
closes #27 
This PR addresses the issue of multiple entries for the same Artifact log ID displayed in the search results due to various Artifact events for a particular Artifact Log ID.

### Changes Made
1. Showing the latest entry for an Artifact Log ID on the find Page
2. Remove the Artifact Event Id field from UI and instead show the anchor link over the Artifact Log Id

### Note
**Removal of Pagination**: Due to limitations with OpenSearch’s support for aggregation with pagination, pagination has been removed from the Find page. This change was necessary to ensure we could retrieve the most recent events for Artifact log IDs by applying aggregations.

From now on, the find page only shows 20 Results by default, and if the user searches on the find page then it shows all the records without any pagination.

