### PR TITLE
Feat: Added the Artifact status dropdown on find page

### DIFF
--- a/data/ArtifactSeedData.xml
+++ b/data/ArtifactSeedData.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <entity-facade-xml type="ext-seed">
-    <!-- Seed Data for ArtifactLogType -->
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="SALES_ORDER" artifactLogTypeName="Sales Order"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PRODUCT" artifactLogTypeName="Product"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="TRANSFER_ORDER" artifactLogTypeName="Transfer Order"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PURCHASE_ORDER" artifactLogTypeName="Purchase Order"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="INVENTORY" artifactLogTypeName="Inventory"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="FULFILLMENT" artifactLogTypeName="Fulfillment"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="RETURN" artifactLogTypeName="Return"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="CYCLE_COUNT" artifactLogTypeName="Cycle Count"/>
-    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PARTY" artifactLogTypeName="Party"/>
+    <!-- Seed Data for ArtifactLogType -->
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="SALES_ORDER" artifactLogTypeName="Sales Order"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PRODUCT" artifactLogTypeName="Product"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="TRANSFER_ORDER" artifactLogTypeName="Transfer Order"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PURCHASE_ORDER" artifactLogTypeName="Purchase Order"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="INVENTORY" artifactLogTypeName="Inventory"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="FULFILLMENT" artifactLogTypeName="Fulfillment"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="RETURN" artifactLogTypeName="Return"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="CYCLE_COUNT" artifactLogTypeName="Cycle Count"/>
+    <co.hotwax.alc.ArtifactLogType artifactLogTypeId="PARTY" artifactLogTypeName="Party"/>
 
-    <!-- Seed Data for SystemMessageRemote -->
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="SHOPIFY" systemMessageRemoteName="Shopify"/>
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="HOTWAX" systemMessageRemoteName="HotWax"/>
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="NETSUITE" systemMessageRemoteName="NetSuite"/>
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="LOOP" systemMessageRemoteName="Loop"/>
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="ITERABLE" systemMessageRemoteName="Iterable"/>
-    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="SHIPHAWK" systemMessageRemoteName="ShipHawk"/>
+    <!-- Seed Data for SystemMessageRemote -->
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="SHOPIFY" systemMessageRemoteName="Shopify"/>
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="HOTWAX" systemMessageRemoteName="HotWax"/>
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="NETSUITE" systemMessageRemoteName="NetSuite"/>
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="LOOP" systemMessageRemoteName="Loop"/>
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="ITERABLE" systemMessageRemoteName="Iterable"/>
+    <moqui.service.message.SystemMessageRemote systemMessageRemoteId="SHIPHAWK" systemMessageRemoteName="ShipHawk"/>
 
-    <!-- Seed Data for ArtifactLogIdType -->
-    <co.hotwax.alc.ArtifactLogIdType artifactLogIdTypeId="INTERNAL" artifactLogIdTypeName="Internal Id"/>
-    <co.hotwax.alc.ArtifactLogIdType artifactLogIdTypeId="COMMON" artifactLogIdTypeName="Commonly Known Id"/>
+    <!-- Seed Data for ArtifactLogIdType -->
+    <co.hotwax.alc.ArtifactLogIdType artifactLogIdTypeId="INTERNAL" artifactLogIdTypeName="Internal Id"/>
+    <co.hotwax.alc.ArtifactLogIdType artifactLogIdTypeId="COMMON" artifactLogIdTypeName="Commonly Known Id"/>
 </entity-facade-xml>

--- a/data/ComponentSetupData.xml
+++ b/data/ComponentSetupData.xml
@@ -3,6 +3,7 @@
 <entity-facade-xml type="ext-seed">
     <artifactGroups artifactGroupId="ALC_APP" description="Artifact Life Cycle app">
         <artifacts artifactName="component://artifactLifeCycle/screen/ArtifactLifeCycleApp.xml" artifactTypeEnumId="AT_XML_SCREEN" inheritAuthz="Y"/>
+        <artifacts artifactName="/artifact-life-cycle" artifactTypeEnumId="AT_REST_PATH" inheritAuthz="Y"/>
         <!-- Full permissions for the ADMIN user group -->
         <authz artifactAuthzId="ALC_APP_ADMIN" userGroupId="ADMIN" authzTypeEnumId="AUTHZT_ALWAYS" authzActionEnumId="AUTHZA_ALL"/>
     </artifactGroups>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -19,8 +19,16 @@ along with this software (see the LICENSE.md file). If not, see
         <default-response url="../ViewArtifactEvent"/>
     </transition>
     <actions>
+        <set field="statusId" from="statusId ?: 'Open'"/>
+        <set field="statusId_op" value="in"/>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#RecentArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
+        <script>
+            Map additionalQueryMap = [
+                fields: [artifactLogTypeId:artifactLogTypeId, statusId:statusId],
+                operators: [artifactLogTypeId_op:artifactLogTypeId_op, statusId_op:statusId_op]
+            ]
+        </script>
+        <service-call name="co.hotwax.alc.SearchServices.search#RecentArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:additionalQueryMap, pageNoLimit:!anyField]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>
@@ -33,10 +41,21 @@ along with this software (see the LICENSE.md file). If not, see
                     </entity-options>
                 </drop-down>
             </default-field></field>
+            <field name="statusId"><default-field title="Artifact Status">
+                <drop-down allow-multiple="true" no-current-selected-key="statusId">
+                    <entity-options key="${statusId}">
+                        <entity-find entity-name="moqui.basic.StatusItem" cache="true">
+                            <econdition field-name="statusTypeId" value="ArtifactEvent"/>
+                            <select-field field-name="statusId"/>
+                        </entity-find>
+                    </entity-options>
+                </drop-down>
+            </default-field></field>
             <field name="submitButton"><default-field title="Search"><submit/></default-field></field>
             <field-layout><field-row-big>
                 <field-ref name="anyField"/>
                 <field-ref name="artifactLogTypeId"/>
+                <field-ref name="statusId"/>
                 <field-ref name="submitButton"/>
             </field-row-big></field-layout>
         </form-single>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <actions>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageIndex:pageIndex, pageSize:pageSize, pageNoLimit:pageNoLimit]" out-map="context"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#DistantArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>
@@ -40,17 +40,15 @@ along with this software (see the LICENSE.md file). If not, see
                 <field-ref name="submitButton"/>
             </field-row-big></field-layout>
         </form-single>
+        <label text="Showing only 20 records in case of no search string is given" type="strong" style="text-warning" condition="!anyField"/>
         <form-list name="ArtifactLogIndexList" list="documentList" skip-form="true" header-dialog="true" saved-finds="true"
-                   show-xlsx-button="true" show-csv-button="true" show-page-size="true">
+                   show-xlsx-button="true" show-csv-button="true" paginate="false">
             <field name="artifactEventId">
                 <header-field show-order-by="true"/>
-                <default-field><link url="viewArtifactEvent" text="${artifactEventId}" link-type="anchor"/></default-field>
-            </field>
-            <field name="artifactLogId">
-                <header-field show-order-by="true"><text-line size="20"/></header-field>
-                <default-field><display/></default-field>
+                <default-field title="Artifact Log Id"><link url="viewArtifactEvent" text="${artifactLogId}" link-type="anchor-button"/></default-field>
             </field>
 
+            <field name="statusId"><default-field><display/></default-field></field>
             <field name="artifactLogTypeId"><default-field><display/></default-field></field>
             <field name="fromSystem"><default-field><display/></default-field></field>
             <field name="toSystem"><default-field><display/></default-field></field>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -20,7 +20,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
     <actions>
         <set field="queryString" from="anyField ?: '*' "/>
-        <service-call name="co.hotwax.alc.SearchServices.search#DistantArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
+        <service-call name="co.hotwax.alc.SearchServices.search#RecentArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:[artifactLogTypeId: artifactLogTypeId], pageNoLimit:!anyField]" out-map="context"/>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -13,15 +13,9 @@ along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-3.xsd">
-    <service verb="search" noun="ArtifactLogIndexes">
-        <description>
-            Search for ArtifactLogIndex
-        </description>
+    <service verb="search" noun="ArtifactLogDocuments" type="interface">
+        <description>This is interface service for searching Artifact Logs</description>
         <in-parameters>
-            <parameter name="queryString" required="true"/>
-            <parameter name="additionalQueryMap" type="Map">
-                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
-            </parameter>
             <parameter name="pageSize" type="Integer" default="20"/>
             <parameter name="pageIndex" type="Integer" default="0"/>
             <parameter name="pageNoLimit" type="Boolean" default="false"/>
@@ -38,6 +32,17 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="documentListPageRangeLow" type="Integer"/>
             <parameter name="documentListPageRangeHigh" type="Integer"/>
         </out-parameters>
+    </service>
+
+    <service verb="search" noun="ArtifactLogIndexes">
+        <description>Search for ArtifactLogIndex</description>
+        <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
+        <in-parameters>
+            <parameter name="queryString" required="true"/>
+            <parameter name="additionalQueryMap" type="Map">
+                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
+            </parameter>
+        </in-parameters>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
             <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
@@ -77,7 +82,7 @@ along with this software (see the LICENSE.md file). If not, see
                 ]
 
                 if (artifactEventId) {
-                    searchMap.query.bool.must_not = [[match: [artifactEventId: artifactEventId]]]
+                    searchMap.query.bool.must_not = [[term: [artifactEventId: artifactEventId]]]
                 }
 
                 if (additionalQueryMap) {

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -121,7 +121,7 @@ along with this software (see the LICENSE.md file). If not, see
         </actions>
     </service>
     
-    <service verb="search" noun="DistantArtifactLogs">
+    <service verb="search" noun="RecentArtifactLogs">
         <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
@@ -140,7 +140,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                 // In elastic/open search, the aggregations are required to be named
                 def distinctAggName = "distinct"
-                def distantAggName = "distant"
+                def recentAggName = "recent"
 
                 def searchMap = [
                     query: [ bool: [
@@ -152,9 +152,9 @@ along with this software (see the LICENSE.md file). If not, see
                             field: 'artifactLogId',
                             size: 10000
                         ],
-                        aggs: [(distantAggName): [top_hits: [
+                        aggs: [(recentAggName): [top_hits: [
                             sort: [['lastUpdatedStamp': 'desc']],
-                            size: 1 // for getting most distant artifact
+                            size: 1 // for getting only most recent artifact
                         ]]]
                     ]],
                     sort : ["_score"]
@@ -181,9 +181,9 @@ along with this software (see the LICENSE.md file). If not, see
                 documentList = []
 
                 for (Map bucket in bucketsList) {
-                    Map distantHit = (Map) bucket.(distantAggName).hits.hits[0]
-                    Map document = (Map) distantHit._source
-                    document._id = distantHit._id
+                    Map recentHit = (Map) bucket.(recentAggName).hits.hits[0]
+                    Map document = (Map) recentHit._source
+                    document._id = recentHit._id
                     documentList.add(document)
                 }
                 ]]></script>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -16,6 +16,10 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="search" noun="ArtifactLogDocuments" type="interface">
         <description>This is interface service for searching Artifact Logs</description>
         <in-parameters>
+            <parameter name="queryString" required="true"/>
+            <parameter name="additionalQueryMap" type="Map">
+                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
+            </parameter>
             <parameter name="pageSize" type="Integer" default="20"/>
             <parameter name="pageIndex" type="Integer" default="0"/>
             <parameter name="pageNoLimit" type="Boolean" default="false"/>
@@ -37,12 +41,6 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="search" noun="ArtifactLogIndexes">
         <description>Search for ArtifactLogIndex</description>
         <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
-        <in-parameters>
-            <parameter name="queryString" required="true"/>
-            <parameter name="additionalQueryMap" type="Map">
-                <description>Map with key/value pairs. The key is the entity field name and the value is for the exact term search.</description>
-            </parameter>
-        </in-parameters>
         <actions>
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
             <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
@@ -120,6 +118,75 @@ along with this software (see the LICENSE.md file). If not, see
                 if (documentListPageRangeHigh > documentListCount) documentListPageRangeHigh = documentListCount
 
             ]]></script>
+        </actions>
+    </service>
+    
+    <service verb="search" noun="DistantArtifactLogs">
+        <implements service="co.hotwax.alc.SearchServices.search#ArtifactLogDocuments"/>
+        <actions>
+            <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
+            <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
+
+            <script><![CDATA[
+                ed = ec.entity.getEntityDefinition("co.hotwax.alc.ArtifactLogIndex")
+                edf = ed.entityInfo.datasourceFactory
+                indexName = edf.getIndexName(ed)
+                def elasticClient = ec.factory.elastic.getClient(edf.clusterName)
+
+                if(elasticClient == null) {
+                    ec.logger.info("No Elastic Client found for cluster name ${edf.clusterName}, not indexing documents")
+                    return
+                }
+
+                // In elastic/open search, the aggregations are required to be named
+                def distinctAggName = "distinct"
+                def distantAggName = "distant"
+
+                def searchMap = [
+                    query: [ bool: [
+                        should:[[query_string: [query: queryString]]],
+                        minimum_should_match: 1,
+                    ]],
+                    aggs: [(distinctAggName): [
+                        terms: [
+                            field: 'artifactLogId',
+                            size: 10000
+                        ],
+                        aggs: [(distantAggName): [top_hits: [
+                            sort: [['lastUpdatedStamp': 'desc']],
+                            size: 1 // for getting most distant artifact
+                        ]]]
+                    ]],
+                    sort : ["_score"]
+                ]
+
+                if (!queryString) {
+                    searchMap.aggs.(distinctAggName).terms.put("size", 20)
+                }
+
+                if (additionalQueryMap) {
+                    List mustList = additionalQueryMap.findAll { it.value != null }.collect { key, value -> [term: [(key): value]] }
+                    if (!mustList.isEmpty()) searchMap.query.bool.put("must", mustList)
+                }
+
+                Map validateRespMap = elasticClient.validateQuery(index, searchMap.query, true)
+                if (validateRespMap != null) {
+                    ec.message.addMessage("Invalid search: ${queryString}", "danger")
+                    documentListCount = 0
+                    return
+                }
+
+                Map resultMap = elasticClient.search(indexName, searchMap)
+                List<Map> bucketsList = (List) resultMap.aggregations.(distinctAggName).buckets
+                documentList = []
+
+                for (Map bucket in bucketsList) {
+                    Map distantHit = (Map) bucket.(distantAggName).hits.hits[0]
+                    Map document = (Map) distantHit._source
+                    document._id = distantHit._id
+                    documentList.add(document)
+                }
+                ]]></script>
         </actions>
     </service>
 </services>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -127,6 +127,9 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="queryString" from="queryString ? elasticQueryAutoWildcard(queryString, true) : '*'"/>
             <if condition="queryString"><set field="queryString" from="'(' + queryString + ')'"/></if>
 
+            <set field="searchFields" from="additionalQueryMap?.fields"/>
+            <set field="searchFieldsOp" from="additionalQueryMap?.operators"/>
+
             <script><![CDATA[
                 ed = ec.entity.getEntityDefinition("co.hotwax.alc.ArtifactLogIndex")
                 edf = ed.entityInfo.datasourceFactory
@@ -164,8 +167,18 @@ along with this software (see the LICENSE.md file). If not, see
                     searchMap.aggs.(distinctAggName).terms.put("size", 20)
                 }
 
-                if (additionalQueryMap) {
-                    List mustList = additionalQueryMap.findAll { it.value != null }.collect { key, value -> [term: [(key): value]] }
+                if (searchFields) {
+                    List mustList = []
+                    searchFields.each { field, value ->
+                        if(!value) return // skip if no value
+                        def operator = searchFieldsOp?.("${field}_op")
+                        if (operator == 'in') {
+                            def values = value.split(",")
+                            mustList.add([terms: [(field): values]])
+                        } else if (!operator) {
+                            mustList.add([term: [(field): value]])
+                        }
+                    }
                     if (!mustList.isEmpty()) searchMap.query.bool.put("must", mustList)
                 }
 


### PR DESCRIPTION
closes: #34 

This PR implements a feature in the Artifact Find page that allows users to apply the Artifact Status filter.

Changes:
1. Add Status ID dropdown with multiple selects
2. Update the `search#RecentArtifactLogs` logic to make better use of the `additionalQueryMap` to have the support of the `in and equal` operator with filters.