### PR TITLE
Add Tenant Group ID Field and Validation for Tenant Group Membership

### DIFF
--- a/data/TenantData.xml
+++ b/data/TenantData.xml
@@ -3,12 +3,11 @@
 <entity-facade-xml type="ext-seed">
     <moqui.basic.Enumeration description="Tenant" enumId="UgtTenant" enumTypeId="UserGroupType"/>
 
-    <moqui.security.UserGroup userGroupId="AlcAllTenant" description="ALC All Tenant User Group" groupTypeEnumId="UgtTenant"/>
-    <moqui.security.UserGroup userGroupId="AlcAdmin" description="ALC Admin User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AllTenantAuth" description="All Tenant User Group for similar authorization" groupTypeEnumId="UgtTenant"/>
 
-    <moqui.security.UserGroup userGroupId="AlcUcgTenant" description="UCG User Group" groupTypeEnumId="UgtTenant"/>
-    <moqui.security.UserGroup userGroupId="AlcGorjanaTenant" description="Gorjana User Group" groupTypeEnumId="UgtTenant"/>
-    <moqui.security.UserGroup userGroupId="AlcKreweTenant" description="Krewe User Group" groupTypeEnumId="UgtTenant"/>
-    <moqui.security.UserGroup userGroupId="AlcADOCTenant" description="ADOC User Group" groupTypeEnumId="UgtTenant"/>
-    <moqui.security.UserGroup userGroupId="AlcNECTenant" description="NEC User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="Ucg" description="UCG User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="Gorjana" description="Gorjana User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="Krewe" description="Krewe User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="ADOC" description="ADOC User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="NEC" description="NEC User Group" groupTypeEnumId="UgtTenant"/>
 </entity-facade-xml>

--- a/data/TenantData.xml
+++ b/data/TenantData.xml
@@ -5,7 +5,7 @@
 
     <moqui.security.UserGroup userGroupId="AllTenantAuth" description="All Tenant User Group for similar authorization" groupTypeEnumId="UgtTenant"/>
 
-    <moqui.security.UserGroup userGroupId="Ucg" description="UCG User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="UCG" description="UCG User Group" groupTypeEnumId="UgtTenant"/>
     <moqui.security.UserGroup userGroupId="Gorjana" description="Gorjana User Group" groupTypeEnumId="UgtTenant"/>
     <moqui.security.UserGroup userGroupId="Krewe" description="Krewe User Group" groupTypeEnumId="UgtTenant"/>
     <moqui.security.UserGroup userGroupId="ADOC" description="ADOC User Group" groupTypeEnumId="UgtTenant"/>

--- a/data/TenantData.xml
+++ b/data/TenantData.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<entity-facade-xml type="ext-seed">
+    <moqui.basic.Enumeration description="Tenant" enumId="UgtTenant" enumTypeId="UserGroupType"/>
+
+    <moqui.security.UserGroup userGroupId="AlcAllTenant" description="ALC All Tenant User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AlcAdmin" description="ALC Admin User Group" groupTypeEnumId="UgtTenant"/>
+
+    <moqui.security.UserGroup userGroupId="AlcUcgTenant" description="UCG User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AlcGorjanaTenant" description="Gorjana User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AlcKreweTenant" description="Krewe User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AlcADOCTenant" description="ADOC User Group" groupTypeEnumId="UgtTenant"/>
+    <moqui.security.UserGroup userGroupId="AlcNECTenant" description="NEC User Group" groupTypeEnumId="UgtTenant"/>
+</entity-facade-xml>

--- a/entity/ArtifactLifeCycleEntities.xml
+++ b/entity/ArtifactLifeCycleEntities.xml
@@ -32,6 +32,7 @@ under the License.
         <field name="artifactLogTypeId" type="id"/>
         <field name="artifactLogIdTypeId" type="id"/>
         <field name="artifactLogIdSystem" type="id"/>
+        <field name="tenantGroupId" type="id"/>
         <field name="fromSystem" type="id"/>
         <field name="toSystem" type="id"/>
         <field name="logOriginPath" type="text-medium"/>
@@ -49,6 +50,9 @@ under the License.
         <relationship type="one" related="co.hotwax.alc.ArtifactLogType">
             <key-map field-name="artifactLogTypeId"/>
         </relationship>
+        <relationship type="one" related="moqui.security.UserGroup">
+            <key-map field-name="tenantGroupId"/>
+        </relationship>
     </entity>
 
     <!-- This is an Index entity for the ArtifactLog in OpenSearch -->
@@ -58,6 +62,7 @@ under the License.
         <field name="artifactLogTypeId" type="id"/>
         <field name="artifactLogIdTypeId" type="id"/>
         <field name="artifactLogIdSystem" type="id"/>
+        <field name="tenantGroupId" type="id"/>
         <field name="fromSystem" type="id"/>
         <field name="toSystem" type="id"/>
         <field name="logOriginPath" type="text-medium"/>
@@ -67,6 +72,9 @@ under the License.
         <field name="statusId" type="id" default="'Open'" enable-audit-log="true"/>
 
         <relationship type="one" title="ArtifactEvent" related="moqui.basic.StatusItem" short-alias="status" />
+        <relationship type="one" related="moqui.security.UserGroup">
+            <key-map field-name="tenantGroupId"/>
+        </relationship>
 
         <seed-data>
             <moqui.basic.StatusType statusTypeId="ArtifactEvent" description="Artifact Event Status"/>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -117,12 +117,22 @@
         <in-parameters>
             <auto-parameters entity-name="co.hotwax.alc.ArtifactLog" include="nonpk"/>
             <parameter name="uploadedFile" type="org.apache.commons.fileupload.FileItem" required="true"/>
+            <!-- TODO: Do validation -->
         </in-parameters>
         <out-parameters>
             <parameter name="filePath"/>
             <parameter name="artifactEventId"/>
         </out-parameters>
         <actions>
+            <!-- Validate the logged-in user is a member of tenant group -->
+            <entity-find-count entity-name="moqui.security.UserGroupAndMember" count-field="userGroupCount" cache="true">
+                <econdition field-name="userId" from="ec.user.userAccount.userId"/>
+                <econdition field-name="groupTypeEnumId" value="UgtTenant"/>
+                <econdition field-name="userGroupId" from="tenantGroupId"/>
+                <date-filter/>
+            </entity-find-count>
+            <if condition="userGroupCount == 0"><then><return error="true" message="You must be a member of the tenant group to create an Artifact Log"/></then></if>
+
             <set field="result" from="[:]"/>
             <set field="fileName" from="uploadedFile.getName()"/>
             <set field="dateTime" from="ec.l10n.format((ec.user.nowTimestamp), 'yyyy-MM-dd-HH-mm-ss-SSS')"/>


### PR DESCRIPTION
Issue: #42 

### Changes
- **Tenant Group Id**: Added a `tenantGroupId` field to differentiate Artifact Logs across multiple tenants. in the Entities storing Artifact logs
- **Validation**: Added a validation check to the `create#Artifact` service to check the authenticated user is a member of the provided tenant group ID.
