### PR TITLE
Change statusId field position in UI

### DIFF
--- a/entity/ArtifactLifeCycleEntities.xml
+++ b/entity/ArtifactLifeCycleEntities.xml
@@ -62,6 +62,7 @@ under the License.
         <field name="artifactLogTypeId" type="id"/>
         <field name="artifactLogIdTypeId" type="id"/>
         <field name="artifactLogIdSystem" type="id"/>
+        <field name="statusId" type="id" default="'Open'" enable-audit-log="true"/>
         <field name="tenantGroupId" type="id"/>
         <field name="fromSystem" type="id"/>
         <field name="toSystem" type="id"/>
@@ -69,7 +70,6 @@ under the License.
         <field name="logFilePath" type="text-medium"/>
         <field name="eventMessage" type="text-medium"/>
         <field name="content" type="object"/>
-        <field name="statusId" type="id" default="'Open'" enable-audit-log="true"/>
 
         <relationship type="one" title="ArtifactEvent" related="moqui.basic.StatusItem" short-alias="status" />
         <relationship type="one" related="moqui.security.UserGroup">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -57,7 +57,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <box-header title="Artifact Event ${artifactLogIndex.artifactEventId} Details"/>
                     <box-body>
                         <form-single name="ViewArtifactEvent" map="artifactLogIndex" background-submit="true" transition="updateStatus">
-                            <auto-fields-entity entity-name="co.hotwax.alc.ArtifactLogIndex" field-type="display"><exclude field-name="statusId"/></auto-fields-entity>
+                            <auto-fields-entity entity-name="co.hotwax.alc.ArtifactLogIndex" field-type="display"/>
                             <field name="content"><default-field><text-area rows="10" read-only="true"/></default-field></field>
                             <field name="statusId"><default-field>
                                 <drop-down submit-on-select="true" no-current-selected-key="${artifactStatus.statusId}" current-description="${artifactStatus.description} [${artifactStatus.statusId}]">


### PR DESCRIPTION
Close: #48 
Move the position of the `Status Id` on the top field on the View Artifact Screen

#### Before:
![image](https://github.com/user-attachments/assets/d5d188b0-4591-4bfc-aa60-1d64decc0ce0)

#### After: 
![image](https://github.com/user-attachments/assets/8f17f4a3-5b36-49a8-b984-410619beedf8)
