### PR TITLE
Feat: Bulk Action for Related Artifact Events

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -44,6 +44,22 @@ along with this software (see the LICENSE.md file). If not, see
 
         <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
         <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId]"/>
+
+        <!-- Finding the largest status among all the related Artifact events to maintain the valid status change -->
+        <entity-find entity-name="moqui.basic.StatusItem" list="statusList" cache="true">
+            <econdition field-name="statusTypeId" value="ArtifactEvent"/>
+            <select-field field-name="statusId,sequenceNum"/>
+        </entity-find>
+        <script>statusList = statusList.collectEntries { [it.statusId, it.sequenceNum] }</script>
+        <set field="largestStatusSequence" type="Integer" from="-1"/>
+        <set field="largestStatus" value="Open"/>
+        <iterate list="documentList" entry="doc">
+            <set field="seqNum" type="Integer" from="statusList[doc.statusId]"/>
+            <if condition="seqNum > largestStatusSequence"><then>
+                <set field="largestStatusSequence" type="Integer" from="seqNum"/>
+                <set field="largestStatus" from="doc.statusId"/>
+            </then></if>
+        </iterate>
     </actions>
     <widgets>
         <label text="View Artifact Event Details" type="h3"/>
@@ -52,7 +68,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <container-box>
                     <box-header title="Artifact Event ${artifactLogIndex.artifactEventId} Details"/>
                     <box-body>
-                        <form-single name="ViewArtifactEvent" map="artifactLogIndex" background-submit="true" transition="updateStatus">
+                        <form-single name="ViewArtifactEvent" map="artifactLogIndex" transition="updateStatus">
                             <auto-fields-entity entity-name="co.hotwax.alc.ArtifactLogIndex" field-type="display"/>
                             <field name="content"><default-field><text-area rows="10" read-only="true"/></default-field></field>
                             <field name="statusId"><default-field>
@@ -87,6 +103,23 @@ along with this software (see the LICENSE.md file). If not, see
                                 </filter-map-list>
                                 <set field="status" from="currentRowStatus[0]"/>
                             </row-actions>
+                            <row-selection id-field="artifactEventId">
+                                <action>
+                                    <form-single name="Update" transition="updateStatus">
+                                        <field name="statusId">
+                                            <default-field><drop-down>
+                                                <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
+                                                    <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
+                                                        <econdition field-name="fromStatusId" from="largestStatus"/>
+                                                        <select-field field-name="toStatusId,toDescription"/>
+                                                    </entity-find>
+                                                </entity-options>
+                                            </drop-down></default-field>
+                                        </field>
+                                        <field name="submitButton"><default-field title="Update Status"><submit/></default-field></field>
+                                    </form-single>
+                                </action>
+                            </row-selection>
                             <field name="artifactEventId"><default-field><hidden/></default-field></field>
                             <field name="artifactEventLink">
                                 <header-field show-order-by="true"/>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -76,8 +76,11 @@ along with this software (see the LICENSE.md file). If not, see
             <row-col sm="12">
                 <section name="RelatedArtifactEvents">
                     <actions>
+                        <set field="defaultStatusId" value="Open,InProgress"/>
+                        <script>Map additionalQueryMap = [fields: [statusId:filterStatusId?:defaultStatusId], operators: [statusId_op:statusId_op?:'in']]</script>
                         <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
-                        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId]"/>
+
+                        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId, additionalQueryMap:additionalQueryMap]"/>
 
                         <!-- Finding the largest status among all the related Artifact events to maintain the valid status change -->
                         <script>statusSeqMap = artifactStatusList.collectEntries { [it.statusId, it.sequenceNum] }</script>
@@ -94,6 +97,24 @@ along with this software (see the LICENSE.md file). If not, see
                     <widgets><container-box>
                         <box-header title="Related Artifact Events"/>
                         <box-body>
+                            <form-single name="FindArtifactLogIndex" background-submit="true" transition=".">
+                                <field name="artifactEventId"><default-field><hidden/></default-field></field>
+                                <field name="filterStatusId"><default-field title="Artifact Status">
+                                    <drop-down allow-multiple="true" no-current-selected-key="${filterStatusId?:defaultStatusId}">
+                                        <entity-options>
+                                            <entity-find entity-name="moqui.basic.StatusItem" cache="true">
+                                                <econdition field-name="statusTypeId" value="ArtifactEvent"/>
+                                                <select-field field-name="statusId,"/>
+                                            </entity-find>
+                                        </entity-options>
+                                    </drop-down>
+                                </default-field></field>
+                                <field name="submitButton"><default-field title="Search"><submit/></default-field></field>
+                                <field-layout><field-row-big>
+                                    <field-ref name="filterStatusId"/>
+                                    <field-ref name="submitButton"/>
+                                </field-row-big></field-layout>
+                            </form-single>
                             <form-list name="ArtifactLogIndexList" list="documentList" show-page-size="true" transition="updateStatus" multi="true">
                                 <row-actions>
                                     <filter-map-list list="artifactStatusList" to-list="currentRowStatus">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -77,7 +77,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <section name="RelatedArtifactEvents">
                     <actions>
                         <set field="defaultStatusId" value="Open,InProgress"/>
-                        <script>Map additionalQueryMap = [fields: [statusId:filterStatusId?:defaultStatusId], operators: [statusId_op:statusId_op?:'in']]</script>
+                        <script>Map additionalQueryMap = [fields: [statusId:(filterStatusId?:defaultStatusId).split(',')], operators: [statusId_op:statusId_op?:'in']]</script>
                         <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
 
                         <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId, additionalQueryMap:additionalQueryMap]"/>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -23,11 +23,7 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
 
     <transition name="updateStatus">
-        <actions>
-            <entity-find-one entity-name="co.hotwax.alc.ArtifactLogIndex" value-field="updateLogIndex" for-update="true"/>
-            <set field="updateLogIndex.statusId" from="statusId"/>
-            <entity-update value-field="updateLogIndex"/>
-        </actions>
+        <service-call name="co.hotwax.alc.ArtifactLifeCycleServices.update#ArtifactLogIndex" in-map="context" multi="parameter"/>
         <default-response type="none"/>
     </transition>
 
@@ -84,16 +80,17 @@ along with this software (see the LICENSE.md file). If not, see
                 <container-box>
                     <box-header title="Related Artifact Events"/>
                     <box-body>
-                        <form-list name="ArtifactLogIndexList" list="documentList" show-page-size="true" transition="updateStatus">
+                        <form-list name="ArtifactLogIndexList" list="documentList" show-page-size="true" transition="updateStatus" multi="true">
                             <row-actions>
                                 <filter-map-list list="artifactStatusList" to-list="currentRowStatus">
                                     <field-map field-name="statusId" from="statusId"/>
                                 </filter-map-list>
                                 <set field="status" from="currentRowStatus[0]"/>
                             </row-actions>
-                            <field name="artifactEventId">
+                            <field name="artifactEventId"><default-field><hidden/></default-field></field>
+                            <field name="artifactEventLink">
                                 <header-field show-order-by="true"/>
-                                <default-field><link url="viewArtifactEvent" text="${artifactEventId}"/></default-field>
+                                <default-field title="ID"><link url="viewArtifactEvent" text="${artifactEventId}"/></default-field>
                             </field>
                             <field name="artifactLogId">
                                 <header-field show-order-by="true"/>
@@ -104,7 +101,7 @@ along with this software (see the LICENSE.md file). If not, see
                                 <default-field><display/></default-field></field>
                             <field name="statusId">
                                 <header-field show-order-by="true"/>
-                                <default-field><drop-down submit-on-select="true" no-current-selected-key="${status.statusId}" current-description="${status.description} [${status.statusId}]">
+                                <default-field><drop-down no-current-selected-key="${status.statusId}" current-description="${status.description} [${status.statusId}]">
                                     <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
                                         <!-- TODO: Fetch the complete list of ArtifactStatusAndFlowTransition at once instead of for each row -->
                                         <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
@@ -126,6 +123,7 @@ along with this software (see the LICENSE.md file). If not, see
                                     </container-dialog>
                                 </default-field>
                             </field>
+                            <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
                         </form-list>
                     </box-body>
                 </container-box>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -33,33 +33,14 @@ along with this software (see the LICENSE.md file). If not, see
             <return message="Artifact Log ${artifactEventId} is not found"/>
         </if>
 
-        <entity-find entity-name="moqui.basic.StatusItem" list="artifactStatusList">
+        <entity-find entity-name="moqui.basic.StatusItem" list="artifactStatusList" cache="true">
             <econdition field-name="statusTypeId" value="ArtifactEvent"/>
-            <select-field field-name="toStatusId,toDescription"/>
+            <select-field field-name="statusId,sequenceNum,description"/>
         </entity-find>
         <filter-map-list list="artifactStatusList" to-list="currentStatus">
             <field-map field-name="statusId" from="artifactLogIndex.statusId"/>
         </filter-map-list>
         <set field="artifactStatus" from="currentStatus[0]"/>
-
-        <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
-        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId]"/>
-
-        <!-- Finding the largest status among all the related Artifact events to maintain the valid status change -->
-        <entity-find entity-name="moqui.basic.StatusItem" list="statusList" cache="true">
-            <econdition field-name="statusTypeId" value="ArtifactEvent"/>
-            <select-field field-name="statusId,sequenceNum"/>
-        </entity-find>
-        <script>statusList = statusList.collectEntries { [it.statusId, it.sequenceNum] }</script>
-        <set field="largestStatusSequence" type="Integer" from="-1"/>
-        <set field="largestStatus" value="Open"/>
-        <iterate list="documentList" entry="doc">
-            <set field="seqNum" type="Integer" from="statusList[doc.statusId]"/>
-            <if condition="seqNum > largestStatusSequence"><then>
-                <set field="largestStatusSequence" type="Integer" from="seqNum"/>
-                <set field="largestStatus" from="doc.statusId"/>
-            </then></if>
-        </iterate>
     </actions>
     <widgets>
         <label text="View Artifact Event Details" type="h3"/>
@@ -93,73 +74,91 @@ along with this software (see the LICENSE.md file). If not, see
         </container-row>
         <container-row>
             <row-col sm="12">
-                <container-box>
-                    <box-header title="Related Artifact Events"/>
-                    <box-body>
-                        <form-list name="ArtifactLogIndexList" list="documentList" show-page-size="true" transition="updateStatus" multi="true">
-                            <row-actions>
-                                <filter-map-list list="artifactStatusList" to-list="currentRowStatus">
-                                    <field-map field-name="statusId" from="statusId"/>
-                                </filter-map-list>
-                                <set field="status" from="currentRowStatus[0]"/>
-                            </row-actions>
-                            <row-selection id-field="artifactEventId">
-                                <action>
-                                    <form-single name="Update" transition="updateStatus">
-                                        <field name="statusId">
-                                            <default-field><drop-down>
-                                                <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
-                                                    <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
-                                                        <econdition field-name="fromStatusId" from="largestStatus"/>
-                                                        <select-field field-name="toStatusId,toDescription"/>
-                                                    </entity-find>
-                                                </entity-options>
-                                            </drop-down></default-field>
-                                        </field>
-                                        <field name="submitButton"><default-field title="Update Status"><submit/></default-field></field>
-                                    </form-single>
-                                </action>
-                            </row-selection>
-                            <field name="artifactEventId"><default-field><hidden/></default-field></field>
-                            <field name="artifactEventLink">
-                                <header-field show-order-by="true"/>
-                                <default-field title="ID"><link url="viewArtifactEvent" text="${artifactEventId}"/></default-field>
-                            </field>
-                            <field name="artifactLogId">
-                                <header-field show-order-by="true"/>
-                                <default-field><display/></default-field>
-                            </field>
-                            <field name="artifactLogTypeId">
-                                <header-field show-order-by="true"/>
-                                <default-field><display/></default-field></field>
-                            <field name="statusId">
-                                <header-field show-order-by="true"/>
-                                <default-field><drop-down no-current-selected-key="${status.statusId}" current-description="${status.description} [${status.statusId}]">
-                                    <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
-                                        <!-- TODO: Fetch the complete list of ArtifactStatusAndFlowTransition at once instead of for each row -->
-                                        <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
-                                            <econdition field-name="fromStatusId" from="status.statusId"/>
-                                            <select-field field-name="toStatusId,toDescription"/>
-                                        </entity-find>
-                                    </entity-options>
-                                </drop-down></default-field>
-                            </field>
-                            <field name="fromSystem"><default-field><display/></default-field></field>
-                            <field name="toSystem"><default-field><display/></default-field></field>
-                            <field name="eventMessage"><default-field><display/></default-field></field>
-                            <field name="content">
-                                <default-field>
-                                    <container-dialog id="contentDialog" button-text="View Content">
-                                        <form-single name="ContentForm">
-                                            <field name="content"><default-field title=""><display/></default-field></field>
+                <section name="RelatedArtifactEvents">
+                    <actions>
+                        <set field="artifactLogId" from="artifactLogIndex.artifactLogId"/>
+                        <service-call name="co.hotwax.alc.SearchServices.search#ArtifactLogIndexes" out-map="context" in-map="context + [queryString:artifactLogId]"/>
+
+                        <!-- Finding the largest status among all the related Artifact events to maintain the valid status change -->
+                        <script>statusSeqMap = artifactStatusList.collectEntries { [it.statusId, it.sequenceNum] }</script>
+                        <set field="largestStatusSequence" type="Integer" from="-1"/>
+                        <set field="largestStatus" value="Open"/>
+                        <iterate list="documentList" entry="doc">
+                            <set field="seqNum" type="Integer" from="statusSeqMap[doc.statusId]"/>
+                            <if condition="seqNum > largestStatusSequence"><then>
+                                <set field="largestStatusSequence" type="Integer" from="seqNum"/>
+                                <set field="largestStatus" from="doc.statusId"/>
+                            </then></if>
+                        </iterate>
+                    </actions>
+                    <widgets><container-box>
+                        <box-header title="Related Artifact Events"/>
+                        <box-body>
+                            <form-list name="ArtifactLogIndexList" list="documentList" show-page-size="true" transition="updateStatus" multi="true">
+                                <row-actions>
+                                    <filter-map-list list="artifactStatusList" to-list="currentRowStatus">
+                                        <field-map field-name="statusId" from="statusId"/>
+                                    </filter-map-list>
+                                    <set field="status" from="currentRowStatus[0]"/>
+                                </row-actions>
+                                <row-selection id-field="artifactEventId">
+                                    <action>
+                                        <form-single name="Update" transition="updateStatus">
+                                            <field name="statusId">
+                                                <default-field><drop-down>
+                                                    <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
+                                                        <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
+                                                            <econdition field-name="fromStatusId" from="largestStatus"/>
+                                                            <select-field field-name="toStatusId,toDescription"/>
+                                                        </entity-find>
+                                                    </entity-options>
+                                                </drop-down></default-field>
+                                            </field>
+                                            <field name="submitButton"><default-field title="Update Status"><submit/></default-field></field>
                                         </form-single>
-                                    </container-dialog>
-                                </default-field>
-                            </field>
-                            <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
-                        </form-list>
-                    </box-body>
-                </container-box>
+                                    </action>
+                                </row-selection>
+                                <field name="artifactEventId"><default-field><hidden/></default-field></field>
+                                <field name="artifactEventLink">
+                                    <header-field show-order-by="true"/>
+                                    <default-field title="ID"><link url="viewArtifactEvent" text="${artifactEventId}"/></default-field>
+                                </field>
+                                <field name="artifactLogId">
+                                    <header-field show-order-by="true"/>
+                                    <default-field><display/></default-field>
+                                </field>
+                                <field name="artifactLogTypeId">
+                                    <header-field show-order-by="true"/>
+                                    <default-field><display/></default-field></field>
+                                <field name="statusId">
+                                    <header-field show-order-by="true"/>
+                                    <default-field><drop-down no-current-selected-key="${status.statusId}" current-description="${status.description} [${status.statusId}]">
+                                        <entity-options key="${toStatusId}" text="${toDescription} [${toStatusId}]">
+                                            <!-- TODO: Fetch the complete list of ArtifactStatusAndFlowTransition at once instead of for each row -->
+                                            <entity-find entity-name="co.hotwax.alc.ArtifactStatusAndFlowTransition" cache="true">
+                                                <econdition field-name="fromStatusId" from="status.statusId"/>
+                                                <select-field field-name="toStatusId,toDescription"/>
+                                            </entity-find>
+                                        </entity-options>
+                                    </drop-down></default-field>
+                                </field>
+                                <field name="fromSystem"><default-field><display/></default-field></field>
+                                <field name="toSystem"><default-field><display/></default-field></field>
+                                <field name="eventMessage"><default-field><display/></default-field></field>
+                                <field name="content">
+                                    <default-field>
+                                        <container-dialog id="contentDialog" button-text="View Content">
+                                            <form-single name="ContentForm">
+                                                <field name="content"><default-field title=""><display/></default-field></field>
+                                            </form-single>
+                                        </container-dialog>
+                                    </default-field>
+                                </field>
+                                <field name="submitButton"><default-field title="Update"><submit/></default-field></field>
+                            </form-list>
+                        </box-body>
+                    </container-box></widgets>
+                </section>
             </row-col>
         </container-row>
     </widgets>

--- a/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
+++ b/service/co/hotwax/alc/ArtifactLifeCycleServices.xml
@@ -165,4 +165,11 @@
             <return message="Artifact Log with artifactEventId: ${result.artifactEventId} has been created."/>
         </actions>
     </service>
+
+    <service verb="update" noun="ArtifactLogIndex" type="entity-auto">
+        <in-parameters>
+            <parameter name="artifactEventId" required="true"/>
+            <parameter name="statusId"/>
+        </in-parameters>
+    </service>
 </services>

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -50,6 +50,10 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="fromOffset" from="pageNoLimit ? 0 : pageIndex * pageSize"/>
             <!-- TODO FUTURE: for this type of search ES limits size to 10k (default for index.max_result_window, can be changed per index), must use a scroll search to do more -->
             <set field="sizeLimit" from="pageNoLimit ? 10000 : pageSize"/>
+
+            <set field="searchFields" from="additionalQueryMap?.fields"/>
+            <set field="searchFieldsOp" from="additionalQueryMap?.operators"/>
+
             <script><![CDATA[
                 ed = ec.entity.getEntityDefinition("co.hotwax.alc.ArtifactLogIndex")
                 edf = ed.entityInfo.datasourceFactory
@@ -83,8 +87,18 @@ along with this software (see the LICENSE.md file). If not, see
                     searchMap.query.bool.must_not = [[term: [artifactEventId: artifactEventId]]]
                 }
 
-                if (additionalQueryMap) {
-                    List mustList = additionalQueryMap.findAll { it.value != null }.collect { key, value -> [term: [(key): value]] }
+                if (searchFields) {
+                    List mustList = []
+                    searchFields.each { field, value ->
+                        if(!value) return // skip if no value
+                        def operator = searchFieldsOp?.("${field}_op")
+                        if (operator == 'in') {
+                            def values = value.split(",")
+                            mustList.add([terms: [(field): values]])
+                        } else if (!operator) {
+                            mustList.add([term: [(field): value]])
+                        }
+                    }
                     if (!mustList.isEmpty()) searchMap.query.bool.put("must", mustList)
                 }
 

--- a/service/co/hotwax/alc/SearchServices.xml
+++ b/service/co/hotwax/alc/SearchServices.xml
@@ -93,8 +93,7 @@ along with this software (see the LICENSE.md file). If not, see
                         if(!value) return // skip if no value
                         def operator = searchFieldsOp?.("${field}_op")
                         if (operator == 'in') {
-                            def values = value.split(",")
-                            mustList.add([terms: [(field): values]])
+                            mustList.add([terms: [(field): value]])
                         } else if (!operator) {
                             mustList.add([term: [(field): value]])
                         }


### PR DESCRIPTION
Closes: #46 

#### Description
This introduces a bulk updation functionality for the Artifact detail page. A checkbox is provided for each row, with a checkbox on the header for the "select all" option to enable bulk status updates. 

Additionally, a filter is included to display events, with default settings showing only "Open" and "In Progress" events.

#### Change is Existing design
Submit on select status is removed, providing an `Update` button at the bottom with multi-submit functionality.

#### Note
The bulk action form only shows the options after the largest status among all listed events to maintain the valid status change.
##### Example
![image](https://github.com/user-attachments/assets/f6504abc-90de-4f7f-b6c7-bcf1c374cab6)

#### Status Filter
![image](https://github.com/user-attachments/assets/aed9b034-6fe0-4821-98cb-a49fe25075b5)
