### PR TITLE
Display errorDate in proper date-time format using L10N facade in artifact event page

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -72,6 +72,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <header-field show-order-by="true"/>
                 <default-field title="Artifact Log Id"><link url="viewArtifactEvent" text="${artifactLogId}" link-type="anchor-button"/></default-field>
             </field>
+
             <field name="statusId"><default-field><display/></default-field></field>
             <field name="artifactLogTypeId"><default-field><display/></default-field></field>
             <field name="fromSystem"><default-field><display/></default-field></field>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -72,13 +72,12 @@ along with this software (see the LICENSE.md file). If not, see
                 <header-field show-order-by="true"/>
                 <default-field title="Artifact Log Id"><link url="viewArtifactEvent" text="${artifactLogId}" link-type="anchor-button"/></default-field>
             </field>
-
             <field name="statusId"><default-field><display/></default-field></field>
             <field name="artifactLogTypeId"><default-field><display/></default-field></field>
             <field name="fromSystem"><default-field><display/></default-field></field>
             <field name="toSystem"><default-field><display/></default-field></field>
             <field name="eventMessage"><default-field><display/></default-field></field>
-            <field name="errorDate"><default-field><display/></default-field></field>
+            <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss.SSS')}"/></default-field></field>
             <field name="content">
                 <default-field>
                     <container-dialog id="contentDialog" button-text="Content">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -77,7 +77,7 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="fromSystem"><default-field><display/></default-field></field>
             <field name="toSystem"><default-field><display/></default-field></field>
             <field name="eventMessage"><default-field><display/></default-field></field>
-            <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss.SSS')}"/></default-field></field>
+            <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss')}"/></default-field></field>
             <field name="content">
                 <default-field>
                     <container-dialog id="contentDialog" button-text="Content">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -43,6 +43,7 @@ along with this software (see the LICENSE.md file). If not, see
             <return message="Artifact Log ${artifactEventId} is not found." type="danger" error="true" public="true"/>
         </if>
         <set field="artifactLogIndex" from="artifactLogIndexList.get(0)"/>
+
         <entity-find entity-name="moqui.basic.StatusItem" list="artifactStatusList" cache="true">
             <econdition field-name="statusTypeId" value="ArtifactEvent"/>
             <select-field field-name="statusId,sequenceNum,description"/>

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -176,7 +176,7 @@ along with this software (see the LICENSE.md file). If not, see
                                 <field name="fromSystem"><default-field><display/></default-field></field>
                                 <field name="toSystem"><default-field><display/></default-field></field>
                                 <field name="eventMessage"><default-field><display/></default-field></field>
-                                <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss.SSS')}"/></default-field></field>
+                                <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss')}"/></default-field></field>
                                 <field name="content">
                                     <default-field>
                                         <container-dialog id="contentDialog" button-text="View Content">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -43,7 +43,6 @@ along with this software (see the LICENSE.md file). If not, see
             <return message="Artifact Log ${artifactEventId} is not found." type="danger" error="true" public="true"/>
         </if>
         <set field="artifactLogIndex" from="artifactLogIndexList.get(0)"/>
-
         <entity-find entity-name="moqui.basic.StatusItem" list="artifactStatusList" cache="true">
             <econdition field-name="statusTypeId" value="ArtifactEvent"/>
             <select-field field-name="statusId,sequenceNum,description"/>
@@ -177,7 +176,7 @@ along with this software (see the LICENSE.md file). If not, see
                                 <field name="fromSystem"><default-field><display/></default-field></field>
                                 <field name="toSystem"><default-field><display/></default-field></field>
                                 <field name="eventMessage"><default-field><display/></default-field></field>
-                                <field name="errorDate"><default-field><display/></default-field></field>
+                                <field name="errorDate"><default-field><display text="${ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss.SSS')}"/></default-field></field>
                                 <field name="content">
                                     <default-field>
                                         <container-dialog id="contentDialog" button-text="View Content">


### PR DESCRIPTION
closes: https://github.com/hotwax/artifactLifeCycle/issues/69 

**Issue:** 
On the Find Artifact Event page, the errorDate field was displaying as a plain string instead of a properly formatted date-time. This made it difficult for users to understand the actual error timestamp clearly.

![image](https://github.com/user-attachments/assets/14f553d0-2763-4273-8124-d725b6e58eed)

**Solution :**
Used the format method from the l10n facade to format the errorDate field into a human-readable date-time format. This change ensures that the date is now shown in a localized and user-friendly manner on the UI.

**Changes Made :**
- Updated the display tag for errorDate field.
- Applied L10N.format() method for proper date-time localization and formatting.

![image](https://github.com/user-attachments/assets/9e749613-1b17-4f5a-b034-18162e81bfe9)




