### PR TITLE
Added sorting functionality on Find Artifact Screen

### DIFF
--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/FindArtifactEvent.xml
@@ -35,6 +35,21 @@ along with this software (see the LICENSE.md file). If not, see
             }
         </script>
         <service-call name="co.hotwax.alc.SearchServices.search#RecentArtifactLogs" in-map="[queryString:queryString, additionalQueryMap:additionalQueryMap, pageNoLimit:!anyField]" out-map="context"/>
+        <script>
+            def sortingList = documentList ?: []
+            if (orderByField) {
+            def isdesc = orderByField.startsWith('-')
+            def fieldName = isdesc ? orderByField.substring(1) : orderByField
+            def sortedList = sortingList.sort { it[fieldName] }
+            if (isdesc) {
+            sortedList = sortedList.reverse()
+            }
+            context.put('documentList',sortedList)
+            }
+            else {
+            context.put('documentList',sortingList)
+            }
+        </script>
     </actions>
     <widgets>
         <label text="Find Artifact Event Page" type="h3"/>
@@ -78,7 +93,7 @@ along with this software (see the LICENSE.md file). If not, see
             <field name="fromSystem"><default-field><display/></default-field></field>
             <field name="toSystem"><default-field><display/></default-field></field>
             <field name="eventMessage"><default-field><display/></default-field></field>
-            <field name="errorDate"><default-field><display/></default-field></field>
+            <field name="errorDate"><header-field show-order-by="true"/><default-field><display text="${errorDate ? ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss') : errorDate}"/></default-field></field>
             <field name="content">
                 <default-field>
                     <container-dialog id="contentDialog" button-text="Content">

--- a/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
+++ b/screen/ArtifactLifeCycleApp/ArtifactEvent/ViewArtifactEvent.xml
@@ -177,7 +177,7 @@ along with this software (see the LICENSE.md file). If not, see
                                 <field name="fromSystem"><default-field><display/></default-field></field>
                                 <field name="toSystem"><default-field><display/></default-field></field>
                                 <field name="eventMessage"><default-field><display/></default-field></field>
-                                <field name="errorDate"><default-field><display/></default-field></field>
+                                <field name="errorDate"><default-field><display text="${errorDate ? ec.l10n.format(new Timestamp(context.get('errorDate')), 'yyyy-MM-dd HH:mm:ss') : errorDate }"/></default-field></field>
                                 <field name="content">
                                     <default-field>
                                         <container-dialog id="contentDialog" button-text="View Content">


### PR DESCRIPTION
Closes: https://github.com/hotwax/artifactLifeCycle/issues/70

**Description:**
Adds dynamic sorting functionality on the Find Artifact Screen using Moqui’s **show-order-by="true"** attribute in form fields.

- The screen URL includes an orderByField parameter based on the selected column when enabled.
    **Example:**
    ```/artifactLifeCycle/ArtifactEvent/FindArtifactEvent?orderByField=artifactEventId``` 

- Sorting behavior is based on the value of orderByField:
   - artifactEventId → ascending order
   - -artifactEventId → descending order (**-** prefix indicates descending)
 
 - Sorting is supported on:
   - artifactEventId
   - errorDate
 
- Enhances usability by allowing users to sort data directly through the UI without manual filtering.

![image](https://github.com/user-attachments/assets/474fd43d-91ea-4af2-bc8e-5061b11f0629)
